### PR TITLE
Change HTTP trigger authorization to Anonymous

### DIFF
--- a/Bezalu.ProjectReporting.API/Functions/ProjectCompletionReportFunction.cs
+++ b/Bezalu.ProjectReporting.API/Functions/ProjectCompletionReportFunction.cs
@@ -16,7 +16,7 @@ public class ProjectCompletionReportFunction(
 {
     [Function("GenerateProjectCompletionReport")]
     public async Task<IActionResult> Run(
-        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "reports/project-completion")]
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "reports/project-completion")]
         HttpRequest req,
         CancellationToken cancellationToken)
     {
@@ -53,7 +53,7 @@ public class ProjectCompletionReportFunction(
     // Changed to POST and accepts full report body to avoid regeneration
     [Function("GenerateProjectCompletionReportPdf")]
     public async Task<IActionResult> RunPdf(
-        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "reports/project-completion/pdf")]
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "reports/project-completion/pdf")]
         HttpRequest req,
         CancellationToken cancellationToken)
     {


### PR DESCRIPTION
Updated HTTP trigger authorization level from 'Function' to 'Anonymous' for project completion report functions.  
This allows the SWA function app linking auth to take priority