### PR TITLE
v0.0.4 - Markdown & Report Improvements

### DIFF
--- a/Bezalu.ProjectReporting.API/Bezalu.ProjectReporting.API.csproj
+++ b/Bezalu.ProjectReporting.API/Bezalu.ProjectReporting.API.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
     <PackageReference Include="QuestPDF" Version="2025.12.1" />
+    <PackageReference Include="QuestPDF.Markdown" Version="1.45.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bezalu.ProjectReporting.API/Functions/ReportFunction.cs
+++ b/Bezalu.ProjectReporting.API/Functions/ReportFunction.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using QuestPDF;
 using QuestPDF.Fluent;
 using QuestPDF.Infrastructure;
+using QuestPDF.Markdown;
 
 namespace Bezalu.ProjectReporting.API.Functions;
 
@@ -188,7 +189,7 @@ public class ReportFunction(
             c.Column(col =>
             {
                 col.Item().Text("AI Generated Summary").FontSize(14).Bold();
-                col.Item().Text(report.AiGeneratedSummary ?? string.Empty).FontSize(10);
+                col.Item().DefaultTextStyle(x => x.FontSize(10)).Markdown(report.AiGeneratedSummary ?? string.Empty);
             });
         };
     }

--- a/Bezalu.ProjectReporting.API/Functions/ReportFunction.cs
+++ b/Bezalu.ProjectReporting.API/Functions/ReportFunction.cs
@@ -172,7 +172,7 @@ public class ReportFunction(
             c.Column(col =>
             {
                 col.Item().Text("Budget Analysis").FontSize(14).Bold();
-                col.Item().Text($"Estimated Hours: {b?.EstimatedHours}").FontSize(10);
+                col.Item().Text($"Budget Hours: {b?.BudgetHours}").FontSize(10);
                 col.Item().Text($"Actual Hours: {b?.ActualHours}").FontSize(10);
                 col.Item().Text($"Variance Hours: {b?.VarianceHours}").FontSize(10);
                 col.Item().Text($"Budget Adherence: {b?.BudgetAdherence}").FontSize(10);
@@ -207,7 +207,7 @@ public class ReportFunction(
                         if (phase is { ActualStart: not null, ActualEnd: not null })
                             inner.Item().Text($"Actual: {phase.ActualStart:yyyy-MM-dd} > {phase.ActualEnd:yyyy-MM-dd}")
                                 .FontSize(9);
-                        inner.Item().Text($"Hours est/actual: {phase.EstimatedHours}/{phase.ActualHours}").FontSize(9);
+                        inner.Item().Text($"Hours budget/actual: {phase.BudgetHours}/{phase.ActualHours}").FontSize(9);
                     });
             });
         };
@@ -226,7 +226,7 @@ public class ReportFunction(
                     {
                         inner.Item().Text($"#{ticket.TicketNumber} {ticket.Summary} ({ticket.Status})").SemiBold();
                         inner.Item().Text($"Type: {ticket.Type}/{ticket.SubType}").FontSize(9);
-                        inner.Item().Text($"Hours est/actual: {ticket.EstimatedHours}/{ticket.ActualHours}")
+                        inner.Item().Text($"Hours budget/actual: {ticket.BudgetHours}/{ticket.ActualHours}")
                             .FontSize(9);
                         if (ticket.ClosedDate != null)
                             inner.Item().Text($"Closed: {ticket.ClosedDate:yyyy-MM-dd}").FontSize(9);

--- a/Bezalu.ProjectReporting.API/Models/ConnectWiseModels.cs
+++ b/Bezalu.ProjectReporting.API/Models/ConnectWiseModels.cs
@@ -10,6 +10,7 @@ public class CWProject
     public DateTime? EstimatedStart { get; set; }
     public DateTime? EstimatedEnd { get; set; }
     public decimal? EstimatedHours { get; set; }
+    public decimal? BudgetHours { get; set; }
     public decimal? ActualHours { get; set; }
     public CWReference? Manager { get; set; }
     public CWReference? Company { get; set; }
@@ -32,6 +33,7 @@ public class CWTicket
     public CWReference? Type { get; set; }
     public CWReference? SubType { get; set; }
     public decimal? EstimatedHours { get; set; }
+    public decimal? BudgetHours { get; set; }
     public decimal? ActualHours { get; set; }
     public DateTime? ClosedDate { get; set; }
     public CWReference? AssignedTo { get; set; }
@@ -53,6 +55,7 @@ public class CWPhase
     public DateTime? ActualStart { get; set; }
     public DateTime? ActualEnd { get; set; }
     public decimal? EstimatedHours { get; set; }
+    public decimal? BudgetHours { get; set; }
     public decimal? ActualHours { get; set; }
 }
 

--- a/Bezalu.ProjectReporting.API/Services/ProjectReportingService.cs
+++ b/Bezalu.ProjectReporting.API/Services/ProjectReportingService.cs
@@ -131,20 +131,20 @@ public class ProjectReportingService(
             };
         }
 
-        var estimatedHours = project.EstimatedHours ?? 0;
+        var budgetHours = project.BudgetHours ?? 0;
         var actualHours = project.ActualHours ?? 0;
-        var hoursVariance = actualHours - estimatedHours;
+        var hoursVariance = actualHours - budgetHours;
 
         report.Budget = new BudgetAnalysis
         {
-            EstimatedHours = estimatedHours,
+            BudgetHours = budgetHours,
             ActualHours = actualHours,
             VarianceHours = hoursVariance,
             EstimatedCost = 0,
             ActualCost = 0,
             VarianceCost = 0,
-            BudgetAdherence = hoursVariance <= 0 ? "Under Budget" : hoursVariance <= estimatedHours * 0.1m ? "Slightly Over" : "Over Budget",
-            CostPerformance = estimatedHours > 0 ? $"{(double)(actualHours / estimatedHours) * 100:F1}%" : "N/A"
+            BudgetAdherence = hoursVariance <= 0 ? "Under Budget" : hoursVariance <= budgetHours * 0.1m ? "Slightly Over" : "Over Budget",
+            CostPerformance = budgetHours > 0 ? $"{(double)(actualHours / budgetHours) * 100:F1}%" : "N/A"
         };
 
         report.Phases = phases.Select(phase => new PhaseDetail
@@ -154,7 +154,7 @@ public class ProjectReportingService(
             Status = phase.Status?.Name,
             ActualStart = phase.ActualStart,
             ActualEnd = phase.ActualEnd,
-            EstimatedHours = phase.EstimatedHours ?? 0,
+            BudgetHours = phase.BudgetHours ?? 0,
             ActualHours = phase.ActualHours ?? 0,
             Notes = new List<string>()
         }).ToList();
@@ -167,7 +167,7 @@ public class ProjectReportingService(
             Status = ticket.Status?.Name,
             Type = ticket.Type?.Name,
             SubType = ticket.SubType?.Name,
-            EstimatedHours = ticket.EstimatedHours ?? 0,
+            BudgetHours = ticket.BudgetHours ?? 0,
             ActualHours = ticket.ActualHours ?? 0,
             Notes = ticketNotes.TryGetValue(ticket.Id ?? 0, out var notes)
                 ? notes.OrderBy(n => n.DateCreated).Select(n => n.Text ?? "").ToList()
@@ -205,7 +205,7 @@ public class ProjectReportingService(
         sb.AppendLine("BUDGET:");
         if (report.Budget != null)
         {
-            sb.AppendLine($"- Estimated: {report.Budget.EstimatedHours} hours");
+            sb.AppendLine($"- Budget: {report.Budget.BudgetHours} hours");
             sb.AppendLine($"- Actual: {report.Budget.ActualHours} hours");
             sb.AppendLine($"- Variance: {report.Budget.VarianceHours} hours ({report.Budget.BudgetAdherence})");
         }
@@ -223,7 +223,7 @@ public class ProjectReportingService(
         sb.AppendLine($"PHASES ({report.Phases?.Count ?? 0}):");
         foreach (var phase in report.Phases ?? new List<PhaseDetail>())
         {
-            sb.AppendLine($"- {phase.PhaseName}: {phase.Status}; Hours est/actual {phase.EstimatedHours}/{phase.ActualHours}");
+            sb.AppendLine($"- {phase.PhaseName}: {phase.Status}; Hours budget/actual {phase.BudgetHours}/{phase.ActualHours}");
         }
         sb.AppendLine();
 
@@ -231,7 +231,7 @@ public class ProjectReportingService(
         sb.AppendLine($"TICKETS ({report.Tickets?.Count ?? 0}):");
         foreach (var ticket in report.Tickets ?? new List<TicketSummary>())
         {
-            sb.AppendLine($"- Ticket #{ticket.TicketNumber} {ticket.Summary} (Status: {ticket.Status}, Type: {ticket.Type}/{ticket.SubType}, Hours est/actual {ticket.EstimatedHours}/{ticket.ActualHours})");
+            sb.AppendLine($"- Ticket #{ticket.TicketNumber} {ticket.Summary} (Status: {ticket.Status}, Type: {ticket.Type}/{ticket.SubType}, Hours budget/actual {ticket.BudgetHours}/{ticket.ActualHours})");
             if (ticketNotes.TryGetValue(ticket.TicketId, out var notes) && notes.Any())
             {
                 var limited = notes.OrderBy(n => n.DateCreated).ToList(); // cap to 20 per ticket

--- a/Bezalu.ProjectReporting.Shared/DTOs/ProjectCompletionReportModels.cs
+++ b/Bezalu.ProjectReporting.Shared/DTOs/ProjectCompletionReportModels.cs
@@ -49,7 +49,7 @@ public class TimelineAnalysis
 
 public class BudgetAnalysis
 {
- public decimal EstimatedHours { get; set; }
+ public decimal BudgetHours { get; set; }
  public decimal ActualHours { get; set; }
  public decimal VarianceHours { get; set; }
  public decimal EstimatedCost { get; set; }
@@ -66,7 +66,7 @@ public class PhaseDetail
  public string? Status { get; set; }
  public DateTime? ActualStart { get; set; }
  public DateTime? ActualEnd { get; set; }
- public decimal EstimatedHours { get; set; }
+ public decimal BudgetHours { get; set; }
  public decimal ActualHours { get; set; }
  public List<string>? Notes { get; set; }
  public string? Summary { get; set; }
@@ -80,7 +80,7 @@ public class TicketSummary
  public string? Status { get; set; }
  public string? Type { get; set; }
  public string? SubType { get; set; }
- public decimal EstimatedHours { get; set; }
+ public decimal BudgetHours { get; set; }
  public decimal ActualHours { get; set; }
  public List<string>? Notes { get; set; }
  public DateTime? ClosedDate { get; set; }

--- a/Bezalu.ProjectReporting.Web/Pages/Home.razor
+++ b/Bezalu.ProjectReporting.Web/Pages/Home.razor
@@ -76,14 +76,14 @@ else
         </p>
         <p><b>Manager:</b> @Report.Summary?.Manager | <b>Company:</b> @Report.Summary?.Company</p>
         <p><b>Timeline:</b> @Report.Timeline?.PlannedDays d planned / @Report.Timeline?.TotalDays d actual (Var: @Report.Timeline?.VarianceDays)</p>
-        <p><b>Budget:</b> @Report.Budget?.EstimatedHours h est / @Report.Budget?.ActualHours h actual (Var: @Report.Budget?.VarianceHours)</p>
+        <p><b>Budget:</b> @Report.Budget?.BudgetHours h budget / @Report.Budget?.ActualHours h actual (Var: @Report.Budget?.VarianceHours)</p>
 
         @if (!string.IsNullOrWhiteSpace(Report.AiGeneratedSummary))
         {
             <FluentAccordion>
                 <FluentAccordionItem Heading="AI Summary">
                     <FluentIcon Value="@(new Icons.Regular.Size20.Globe())" Color="Color.Neutral" Slot="start" />
-                    <div>@(new MarkupString(AiSummaryHtml))</div>
+                    <div class="markdown-content">@(new MarkupString(AiSummaryHtml))</div>
                 </FluentAccordionItem>
             </FluentAccordion>
         }
@@ -99,7 +99,7 @@ else
                     <FluentDataGrid Items="@Report.Phases.AsQueryable()" GenerateFooter="false">
                         <PropertyColumn Property="@(p => p.PhaseName)" Title="Name" />
                         <PropertyColumn Property="@(p => p.Status)" Title="Status" />
-                        <PropertyColumn Property="@(p => p.EstimatedHours)" Title="Est Hrs" />
+                        <PropertyColumn Property="@(p => p.BudgetHours)" Title="Budget Hrs" />
                         <PropertyColumn Property="@(p => p.ActualHours)" Title="Actual Hrs" />
                     </FluentDataGrid>
                 }
@@ -115,7 +115,7 @@ else
                         <PropertyColumn Property="@(t => t.TicketNumber)" Title="Number" />
                         <PropertyColumn Property="@(t => t.Summary)" Title="Summary" />
                         <PropertyColumn Property="@(t => t.Status)" Title="Status" />
-                        <PropertyColumn Property="@(t => t.EstimatedHours)" Title="Est Hrs" />
+                        <PropertyColumn Property="@(t => t.BudgetHours)" Title="Budget Hrs" />
                         <PropertyColumn Property="@(t => t.ActualHours)" Title="Actual Hrs" />
                     </FluentDataGrid>
                 }
@@ -125,6 +125,11 @@ else
 }
 
 @code {
+    static readonly MarkdownPipeline MdPipeline = new MarkdownPipelineBuilder()
+        .UseAdvancedExtensions() // enables tables, pipe tables
+        .UseSoftlineBreakAsHardlineBreak()
+        .Build();
+
     List<ProjectListItem>? Projects;
     ProjectCompletionReportResponse? Report;
     bool IsLoadingProjects;
@@ -134,7 +139,7 @@ else
     bool ShowLoginPrompt;
     string LoginPromptText = "Please sign in to continue.";
     string? ErrorMessage;
-    string AiSummaryHtml => Report?.AiGeneratedSummary is null ? string.Empty : Markdown.ToHtml(Report.AiGeneratedSummary);
+    string AiSummaryHtml => Report?.AiGeneratedSummary is null ? string.Empty : Markdown.ToHtml(Report.AiGeneratedSummary, MdPipeline);
 
     protected override async Task OnInitializedAsync()
     {

--- a/Bezalu.ProjectReporting.Web/staticwebapp.config.json
+++ b/Bezalu.ProjectReporting.Web/staticwebapp.config.json
@@ -9,7 +9,7 @@
       "allowedRoles": [ "anonymous" ]
     },
     {
-      "route": "/*",
+      "route": "*",
       "allowedRoles": [ "editor" ]
     }
   ],

--- a/Bezalu.ProjectReporting.Web/wwwroot/css/app.css
+++ b/Bezalu.ProjectReporting.Web/wwwroot/css/app.css
@@ -185,3 +185,29 @@ code {
         right: unset;
     }
 }
+
+.markdown-content table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 0.5rem 0 1rem 0;
+}
+
+.markdown-content th,
+.markdown-content td {
+    border: 1px solid #d2d6dc;
+    padding: 4px 6px;
+    text-align: left;
+}
+
+.markdown-content th {
+    background: #f6f7f9;
+    font-weight: 600;
+}
+
+.markdown-content tbody tr:nth-child(odd) {
+    background: #fafafa;
+}
+
+.markdown-content p {
+    margin: 0.25rem 0 0.5rem;
+}

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -29,7 +29,7 @@
  "schedulePerformance": "121.6%"
  },
  "budget": {
- "estimatedHours":500.0,
+ "budgetHours":500.0,
  "actualHours":550.0,
  "varianceHours":50.0,
  "estimatedCost":0,
@@ -45,7 +45,7 @@
  "status": "Complete",
  "actualStart": "2024-01-01T00:00:00Z",
  "actualEnd": "2024-01-05T00:00:00Z",
- "estimatedHours":40.0,
+ "budgetHours":40.0,
  "actualHours":42.5,
  "notes": ["Initial kickoff done"],
  "summary": null
@@ -59,7 +59,7 @@
  "status": "Closed",
  "type": "Development",
  "subType": "Enhancement",
- "estimatedHours":16.0,
+ "budgetHours":16.0,
  "actualHours":18.25,
  "notes": ["Reviewed by QA", "Minor fixes"]
  }


### PR DESCRIPTION
This pull request standardizes the terminology across the codebase, replacing all references to "Estimated Hours" with "Budget Hours" for projects, phases, and tickets. It also improves markdown rendering for AI-generated summaries, including support for tables, and adds specific CSS styles for markdown tables in the web UI. Additionally, it introduces the `QuestPDF.Markdown` package for PDF generation and updates the API, DTOs, and documentation to match the new terminology.

**Terminology Standardization:**

* Replaced all uses of `EstimatedHours` with `BudgetHours` in models (`CWProject`, `CWTicket`, `CWPhase`), DTOs (`BudgetAnalysis`, `PhaseDetail`, `TicketSummary`), and throughout the API, service, and UI layers to ensure consistency in reporting and data handling. [[1]](diffhunk://#diff-e894e188afed810dc7c34fb39e61ec64d48b6ada8fdca27748b365bf19d739b0R13) [[2]](diffhunk://#diff-e894e188afed810dc7c34fb39e61ec64d48b6ada8fdca27748b365bf19d739b0R36) [[3]](diffhunk://#diff-e894e188afed810dc7c34fb39e61ec64d48b6ada8fdca27748b365bf19d739b0R58) [[4]](diffhunk://#diff-0cd5fb208fc9d433d2dfce0df9913eca314008985c07eea19d44d64427cd02c3L52-R52) [[5]](diffhunk://#diff-0cd5fb208fc9d433d2dfce0df9913eca314008985c07eea19d44d64427cd02c3L69-R69) [[6]](diffhunk://#diff-0cd5fb208fc9d433d2dfce0df9913eca314008985c07eea19d44d64427cd02c3L83-R83) [[7]](diffhunk://#diff-a9e374cea37b5191709c9e1782e213d1633d4fdc1fd43adeb21993687ff0ce0aL134-R147) [[8]](diffhunk://#diff-a9e374cea37b5191709c9e1782e213d1633d4fdc1fd43adeb21993687ff0ce0aL157-R157) [[9]](diffhunk://#diff-a9e374cea37b5191709c9e1782e213d1633d4fdc1fd43adeb21993687ff0ce0aL170-R170) [[10]](diffhunk://#diff-a9e374cea37b5191709c9e1782e213d1633d4fdc1fd43adeb21993687ff0ce0aL208-R208) [[11]](diffhunk://#diff-a9e374cea37b5191709c9e1782e213d1633d4fdc1fd43adeb21993687ff0ce0aL226-R234) [[12]](diffhunk://#diff-2b61635d46f517da584a9759338913e2ef13e5fabccd83148a7a919eb033b1baL175-R176) [[13]](diffhunk://#diff-2b61635d46f517da584a9759338913e2ef13e5fabccd83148a7a919eb033b1baL210-R211) [[14]](diffhunk://#diff-2b61635d46f517da584a9759338913e2ef13e5fabccd83148a7a919eb033b1baL229-R230) [[15]](diffhunk://#diff-0d33c0f31374e88f7104fce491bece6c0e099ad049053955e3a62a3825531772L102-R102) [[16]](diffhunk://#diff-0d33c0f31374e88f7104fce491bece6c0e099ad049053955e3a62a3825531772L118-R118) [[17]](diffhunk://#diff-0d33c0f31374e88f7104fce491bece6c0e099ad049053955e3a62a3825531772L79-R86) [[18]](diffhunk://#diff-7ce2626524ab9db26f37ed22390c115a8e9a06f071f6faee78426918199d2f23L32-R32) [[19]](diffhunk://#diff-7ce2626524ab9db26f37ed22390c115a8e9a06f071f6faee78426918199d2f23L48-R48) [[20]](diffhunk://#diff-7ce2626524ab9db26f37ed22390c115a8e9a06f071f6faee78426918199d2f23L62-R62)

**Markdown Rendering and Styling Improvements:**

* Enhanced markdown support for AI-generated summaries in both PDF and web UI by adding the `QuestPDF.Markdown` package and using an advanced markdown pipeline in Blazor, including table support and improved line breaks. [[1]](diffhunk://#diff-b5bb0d4dd0f00a5477c707ca8eace12f8fd7f9855df7d31ddcb33bc92a7f747dR22) [[2]](diffhunk://#diff-2b61635d46f517da584a9759338913e2ef13e5fabccd83148a7a919eb033b1baR10) [[3]](diffhunk://#diff-2b61635d46f517da584a9759338913e2ef13e5fabccd83148a7a919eb033b1baL191-R192) [[4]](diffhunk://#diff-0d33c0f31374e88f7104fce491bece6c0e099ad049053955e3a62a3825531772R128-R132) [[5]](diffhunk://#diff-0d33c0f31374e88f7104fce491bece6c0e099ad049053955e3a62a3825531772L137-R142)
* Added custom CSS styles for markdown tables and paragraphs to improve readability in the web interface.

**Documentation Updates:**

* Updated example contract documentation to use `budgetHours` instead of `estimatedHours` for consistency with the new terminology. [[1]](diffhunk://#diff-7ce2626524ab9db26f37ed22390c115a8e9a06f071f6faee78426918199d2f23L32-R32) [[2]](diffhunk://#diff-7ce2626524ab9db26f37ed22390c115a8e9a06f071f6faee78426918199d2f23L48-R48) [[3]](diffhunk://#diff-7ce2626524ab9db26f37ed22390c115a8e9a06f071f6faee78426918199d2f23L62-R62)

**Other Minor Changes:**

* Fixed a route pattern in `staticwebapp.config.json` for role-based access.

These changes collectively improve clarity for end users and maintainers by unifying the concept of "budgeted" hours, while also enhancing the appearance and functionality of markdown content in reports.